### PR TITLE
refactoring: QueryDSL 도입

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
@@ -40,7 +40,7 @@ public class UserQueryController {
     }
 
     // 특정 회원 프로필 조회
-    @Operation(summary = "특정 회원 프로필 조회", description = "이름, 학번, 전공, 소개 리턴, 탈퇴한 회원일 경우 null")
+    @Operation(summary = "특정 회원 프로필 조회", description = "이름, 학번, 전공, 소개 조회, 탈퇴한 회원일 경우 null")
     @GetMapping("/{userId}")
     public ResponseEntity<Response<UserProfileResponse>> getUserProfile(
             @Parameter(description = "UserId(PK)", example = "1")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserQueryRepositoryImpl.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserQueryRepositoryImpl.java
@@ -2,11 +2,12 @@ package com.seungwook.ktsp.domain.user.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.seungwook.ktsp.domain.user.dto.UserProfile;
-import com.seungwook.ktsp.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
 import com.querydsl.core.types.Projections;
 
 import java.util.Optional;
+
+import static com.seungwook.ktsp.domain.user.entity.QUser.*;
 
 
 @RequiredArgsConstructor
@@ -14,22 +15,18 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    // userId를 바탕으로 User 프로필 조회
     @Override
     public Optional<UserProfile> findUserProfileById(Long userId) {
-        QUser user = QUser.user;
-
         return Optional.ofNullable(
                 queryFactory
-                        .select(
-                                Projections.constructor(
-                                        UserProfile.class,
-                                        user.name,
-                                        user.major,
-                                        user.studentNumber,
-                                        user.introduction,
-                                        user.status
-                                )
-                        )
+                        .select(Projections.constructor(UserProfile.class,
+                                user.name,
+                                user.major,
+                                user.studentNumber,
+                                user.introduction,
+                                user.status
+                        ))
                         .from(user)
                         .where(user.id.eq(userId))
                         .fetchOne()

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepo
 
     boolean existsByPhoneNumber(String phoneNumber);
 
-    // studentNumber를 밭탕으로 탈퇴하지 않은 User 리턴
+    // studentNumber를 바탕으로 탈퇴하지 않은 User 리턴
     @Query("SELECT u FROM User u WHERE u.studentNumber = :studentNumber AND u.status <> 'WITHDRAWN'")
     Optional<User> findByStudentNumberExceptWithdrawn(@Param("studentNumber") String studentNumber);
 


### PR DESCRIPTION
## 연관된 이슈
#20 QueryDSL 도입

## 작업 내용
- 실수로 dev 브랜치에서 QueryDSL을 도입함
- 기존 UserRepository의 findUserProfileById 메서드를 QueryDSL을 통해서 조회하도록 리팩터링

## 기타
- OpenFeign의 QueryDSL 도입
  - https://til.seungwook.com/900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 사용자 프로필 조회 엔드포인트의 Swagger 설명 문구가 보다 명확하게 수정되었습니다.
  * 일부 주석의 오타가 수정되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->