### PR TITLE
Feat/board 공지사항 조회시 수정 및 삭제 권한이 있는지 제공

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityListResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityListResponse.java
@@ -1,4 +1,0 @@
-package com.seungwook.ktsp.domain.board.type.community.common.dto.response;
-
-public class CommunityListResponse {
-}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityResponse.java
@@ -18,6 +18,7 @@ public class CommunityResponse {
     private final int hits;
     private final String title;
     private final String content;
+    private final boolean manageable;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
     private final List<CommentResponse> comments;

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
@@ -9,13 +9,14 @@ import java.util.List;
 
 public class CommunityMapper {
 
-    public static CommunityResponse toNoticeResponse(Writer writer, Notice notice, List<AttachedFileInfo> attachedFileInfos) {
+    public static CommunityResponse toNoticeResponse(Writer writer, Notice notice, List<AttachedFileInfo> attachedFileInfos, boolean manageable) {
         return new CommunityResponse(
                 writer,
                 notice.getId(),
                 notice.getHits(),
                 notice.getTitle(),
                 notice.getContent(),
+                manageable, // 수정 및 삭제 권한 보유 여부
                 notice.getCreatedAt(),
                 notice.getModifiedAt(),
                 List.of(), // 공지사항은 댓글 없음

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
@@ -10,6 +10,7 @@ import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
 import com.seungwook.ktsp.domain.file.service.FileService;
 import com.seungwook.ktsp.domain.user.mapper.UserMapper;
 import com.seungwook.ktsp.domain.user.service.UserQueryService;
+import com.seungwook.ktsp.global.auth.support.AuthHandler;
 import com.seungwook.ktsp.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -56,8 +57,11 @@ public class NoticeQueryController {
         // 첨부파일
         List<AttachedFileInfo> attachedFileInfos = fileService.getAttachedFileDownloadPath(boardId);
 
-        // 응답 본문(공지사항 + 작성자 + 첨부파일)
-        CommunityResponse response = CommunityMapper.toNoticeResponse(writer, notice, attachedFileInfos);
+        // 수정 및 삭제 권한 소유 여부
+        boolean manageable = AuthHandler.hasManagePermission(writer.getUserId());
+
+        // 응답 본문(작성자 + 공지사항 + 첨부파일)
+        CommunityResponse response = CommunityMapper.toNoticeResponse(writer, notice, attachedFileInfos, manageable);
 
         return ResponseEntity.ok(Response.<CommunityResponse>builder()
                 .message("공지사항 조회 성공")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/entity/Report.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/entity/Report.java
@@ -23,7 +23,7 @@ public class Report extends Board {
 
     // 정적 팩터리
     public static Report createReport(User user, String title, String content) {
-        return new Report(user, MainType.COMMUNITY, SubType.NOTICE, title, content);
+        return new Report(user, MainType.COMMUNITY, SubType.REPORT, title, content);
     }
 
     // 게시글 수정

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/file/service/FileService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/file/service/FileService.java
@@ -90,7 +90,7 @@ public class FileService {
 
         // 파일 삭제 권한이 있는지 검사
         boolean isNotResourceOwner = uploadFile.getUser().getId() != requestUserId;
-        boolean isNotAdmin = !requestUserRole.equals(UserRole.ADMIN);
+        boolean isNotAdmin = requestUserRole != UserRole.ADMIN;
         if (isNotResourceOwner && isNotAdmin)
             throw new FileException(HttpStatus.FORBIDDEN, "파일을 삭제할 권한이 없습니다.");
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/support/AuthHandler.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/support/AuthHandler.java
@@ -3,10 +3,14 @@ package com.seungwook.ktsp.global.auth.support;
 import com.seungwook.ktsp.domain.user.entity.enums.UserRole;
 import com.seungwook.ktsp.global.auth.dto.UserSession;
 import com.seungwook.ktsp.global.auth.exception.UserContextException;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class AuthHandler {
+
+    private static final AuthenticationTrustResolver TRUST = new AuthenticationTrustResolverImpl();
 
     // UserSession 에서 userId 리턴
     public static long getUserId() {
@@ -20,22 +24,51 @@ public class AuthHandler {
         return userSession.getRole();
     }
 
+    // 게시글 관리 권한 보유 여부 리턴
+    public static boolean hasManagePermission(long resourceOwnerId) {
+
+        Authentication authentication = extractAuthentication();
+
+        // 로그인 하지 않은 사용자는 관리 권한 없음
+        if (isAnonymous(authentication)) return false;
+
+        // 로그인 한 사용자라면 UserSession 추출
+        UserSession userSession = extractUserSession(authentication.getPrincipal());
+
+        // 관리 권한 보유 여부 리턴
+        return userSession.getRole() == UserRole.ADMIN || userSession.getId() == resourceOwnerId;
+    }
+
     // SecurityContextHolder 에서 UserSession 추출
     private static UserSession extractUserSessionFromSecurityContext() {
 
-        // 현재 요청의 SecurityContext에서 인증 객체 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = extractAuthentication();
 
         // 인증 객체가 없거나 인증되지 않은 경우 예외 발생
-        if (authentication == null || !authentication.isAuthenticated())
-            throw new UserContextException("로그인이 필요합니다.");
+        if (isAnonymous(authentication)) throw new UserContextException("로그인이 필요합니다.");
 
-        // 인증 객체의 principal이 UserSession이 아닐 경우 예외 발생 (타입 불일치 방어)
-        Object principal = authentication.getPrincipal();
+        return extractUserSession(authentication.getPrincipal());
+    }
+
+    // 인증 객체의 principal이 UserSession이 아닐 경우 예외 발생 (타입 불일치 방어)
+    private static UserSession extractUserSession(Object principal) {
+
+        // 타입 검사
         if (!(principal instanceof UserSession userSession))
             throw new UserContextException("잘못된 인증 세션입니다.");
 
+        // UserSession 반환
         return userSession;
+    }
+
+    // 현재 요청의 SecurityContext에서 인증 객체 추출
+    private static Authentication extractAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    // 로그인하지 않은 사용자인지 검사
+    private static boolean isAnonymous(Authentication authentication) {
+        return authentication == null || TRUST.isAnonymous(authentication) || !authentication.isAuthenticated();
     }
 }
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/handler/AccessHandler.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/handler/AccessHandler.java
@@ -15,6 +15,6 @@ public abstract class AccessHandler {
 
     // 관리자 권한 여부
     private boolean isAdmin() {
-        return AuthHandler.getUserRole().equals(UserRole.ADMIN);
+        return AuthHandler.getUserRole() == UserRole.ADMIN;
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#34 [Feature] 게시글 조회시 수정 및 삭제 권한이 있는지 제공

## 작업 내용
- AuthHandler 수정
  - 게시글 수정 및 삭제 권한이 있는지 체크
  - 로그인하지 않은 사용자인지 검사 로직 강화

컨트롤러에서 AuthHandler.hasManagePermission 메서드를 통해서 관리 권한이 있는지 여부를 클라이언트에 반환할 수 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 커뮤니티 응답에 관리 권한 여부(manageable) 표시가 추가되었습니다.

* **버그 수정**
  * 리포트 생성 시 잘못된 하위 타입이 생성되는 문제를 수정했습니다.

* **리팩터링**
  * 인증 및 권한 확인 로직이 개선되어, 익명 사용자 감지와 관리 권한 체크가 더 명확해졌습니다.
  * 관리자 권한 비교 방식이 일관성 있게 변경되었습니다.

* **기타**
  * 사용되지 않는 CommunityListResponse 클래스가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->